### PR TITLE
Show more per-camera telemetry on SmartDashboard

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -4,26 +4,16 @@
 
 package frc.robot;
 
-import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.wpilibj.Filesystem;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
-import frc.robot.subsystems.Climb;
-import frc.robot.subsystems.IntakeTrack;
-import frc.robot.subsystems.ShooterElevator;
 import frc.robot.subsystems.ShooterFlywheel;
-import frc.robot.subsystems.ShooterPivot;
-
 import frc.robot.commands.ButtonConfig;
-import frc.robot.commands.ControlMap;
-
 import java.io.File;
 import java.io.IOException;
-
-import com.revrobotics.SparkAbsoluteEncoder.Type;
 
 import swervelib.parser.SwerveParser;
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -4,54 +4,21 @@
 
 package frc.robot;
 
-import edu.wpi.first.hal.SimBoolean;
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.CommandScheduler;
-import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.button.CommandJoystick;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 import frc.robot.Constants.OperatorConstants;
-import frc.robot.commands.arm.ShooterElevatorPosInstant;
-import frc.robot.commands.arm.ShooterFlywheelSpeedInstant;
-import frc.robot.commands.arm.ShooterPivotPosInstant;
-import frc.robot.commands.arm.ShooterTrackSpeedInstant;
-import frc.robot.commands.climb.ClimbManual;
-import frc.robot.commands.complex.Collect;
 import frc.robot.commands.complex.CollectAuto;
-import frc.robot.commands.complex.Driveby;
 import frc.robot.commands.complex.DrivebyAuto;
-import frc.robot.commands.complex.Dunk;
-import frc.robot.commands.complex.Panic;
-import frc.robot.commands.complex.PrepAmp;
-import frc.robot.commands.complex.PrepClimb;
-import frc.robot.commands.complex.PrepSpeaker;
-import frc.robot.commands.complex.SimpleClimb;
 import frc.robot.commands.complex.SpeakerAuto;
-import frc.robot.commands.complex.TheBigYeet;
-import frc.robot.commands.complex.Undunk;
-import frc.robot.commands.intake.IntakeRollerSpeedInstant;
-import frc.robot.commands.intake.IntakeTrackSpeedInstant;
-import frc.robot.commands.swervedrive.PathfindingTest;
-import frc.robot.commands.swervedrive.auto.TestingPaths;
 import frc.robot.commands.swervedrive.drivebase.TeleopDrive;
-import frc.robot.constants.ArmPositions;
-import frc.robot.constants.IntakeSpeeds;
-import frc.robot.constants.ShooterSpeeds;
-import frc.robot.subsystems.Climb;
-import frc.robot.subsystems.IntakeTrack;
-import frc.robot.subsystems.ShooterPivot;
 import frc.robot.subsystems.swervedrive.SwerveSubsystem;
 import frc.robot.subsystems.vision.VisionEstimation;
-import swervelib.imu.NavXSwerve;
-
-import java.io.File;
-
-import com.kauailabs.navx.frc.AHRS;
 import com.pathplanner.lib.auto.AutoBuilder;
 import com.pathplanner.lib.auto.NamedCommands;
 

--- a/src/main/java/frc/robot/commands/ButtonConfig.java
+++ b/src/main/java/frc/robot/commands/ButtonConfig.java
@@ -1,32 +1,25 @@
 package frc.robot.commands;
 
-import edu.wpi.first.wpilibj.Joystick;
-import edu.wpi.first.wpilibj.event.EventLoop;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import edu.wpi.first.wpilibj2.command.button.CommandJoystick;
-import edu.wpi.first.wpilibj2.command.button.JoystickButton;
 import frc.robot.Constants;
 import frc.robot.commands.arm.ShooterElevatorPosInstant;
 import frc.robot.commands.arm.ShooterFlywheelSpeedInstant;
 import frc.robot.commands.complex.Collect;
 import frc.robot.commands.complex.Driveby;
-import frc.robot.commands.complex.Dunk;
 import frc.robot.commands.complex.Panic;
 import frc.robot.commands.complex.PrepAmp;
 import frc.robot.commands.complex.PrepClimb;
 import frc.robot.commands.complex.PrepSpeaker;
 import frc.robot.commands.complex.SimpleClimb;
 import frc.robot.commands.complex.TheBigYeet;
-import frc.robot.commands.complex.Undunk;
 import frc.robot.commands.swervedrive.ToggleTurnTo180;
 import frc.robot.commands.swervedrive.ToggleTurnToAmp;
 import frc.robot.commands.swervedrive.ToggleTurnToSource;
 import frc.robot.commands.swervedrive.ToggleTurnToSpeaker;
 import frc.robot.constants.ArmPositions;
 import frc.robot.constants.ShooterSpeeds;
-import frc.robot.subsystems.Climb;
-import frc.robot.subsystems.ShooterFlywheel;
 import frc.robot.subsystems.swervedrive.SwerveSubsystem;
 
 public class ButtonConfig {

--- a/src/main/java/frc/robot/commands/CancelAllCommands.java
+++ b/src/main/java/frc/robot/commands/CancelAllCommands.java
@@ -2,8 +2,6 @@ package frc.robot.commands;
 
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
-import frc.robot.subsystems.IntakeRoller;
-import frc.robot.constants.IntakeSpeeds;
 
 public class CancelAllCommands extends InstantCommand {
 

--- a/src/main/java/frc/robot/commands/complex/Collect.java
+++ b/src/main/java/frc/robot/commands/complex/Collect.java
@@ -10,7 +10,6 @@ import edu.wpi.first.wpilibj2.command.WaitUntilCommand;
 import frc.robot.commands.arm.JiggleNote;
 import frc.robot.commands.arm.ShooterElevatorPosInstant;
 import frc.robot.commands.arm.ShooterElevatorPosTolerance;
-import frc.robot.commands.arm.ShooterFlywheelSpeedInstant;
 import frc.robot.commands.arm.ShooterPivotPosInstant;
 import frc.robot.commands.arm.ShooterPivotPosTolerance;
 import frc.robot.commands.arm.ShooterTrackSpeedInstant;

--- a/src/main/java/frc/robot/commands/complex/CollectAuto.java
+++ b/src/main/java/frc/robot/commands/complex/CollectAuto.java
@@ -10,7 +10,6 @@ import edu.wpi.first.wpilibj2.command.WaitUntilCommand;
 import frc.robot.commands.arm.JiggleNote;
 import frc.robot.commands.arm.ShooterElevatorPosInstant;
 import frc.robot.commands.arm.ShooterElevatorPosTolerance;
-import frc.robot.commands.arm.ShooterFlywheelSpeedInstant;
 import frc.robot.commands.arm.ShooterPivotPosInstant;
 import frc.robot.commands.arm.ShooterPivotPosTolerance;
 import frc.robot.commands.arm.ShooterTrackSpeedInstant;
@@ -20,7 +19,6 @@ import frc.robot.constants.ArmPositions;
 import frc.robot.constants.IntakeSpeeds;
 import frc.robot.constants.ShooterSpeeds;
 import frc.robot.subsystems.IntakeTrack;
-import frc.robot.subsystems.ShooterPivot;
 import frc.robot.subsystems.ShooterTrack;
 
 public class CollectAuto extends SequentialCommandGroup {

--- a/src/main/java/frc/robot/commands/complex/Driveby.java
+++ b/src/main/java/frc/robot/commands/complex/Driveby.java
@@ -14,7 +14,6 @@ import frc.robot.robot.ControlMap;
 import frc.robot.subsystems.ReverseKinematics;
 import frc.robot.subsystems.ShooterFlywheel;
 import frc.robot.subsystems.ShooterPivot;
-import frc.robot.subsystems.ShooterTrack;
 import frc.robot.subsystems.swervedrive.SwerveSubsystem;
 import frc.robot.util.MathUtil;
 

--- a/src/main/java/frc/robot/commands/complex/DrivebyAuto.java
+++ b/src/main/java/frc/robot/commands/complex/DrivebyAuto.java
@@ -15,7 +15,6 @@ import frc.robot.robot.ControlMap;
 import frc.robot.subsystems.ReverseKinematics;
 import frc.robot.subsystems.ShooterFlywheel;
 import frc.robot.subsystems.ShooterPivot;
-import frc.robot.subsystems.ShooterTrack;
 import frc.robot.subsystems.swervedrive.SwerveSubsystem;
 import frc.robot.util.MathUtil;
 

--- a/src/main/java/frc/robot/commands/complex/Panic.java
+++ b/src/main/java/frc/robot/commands/complex/Panic.java
@@ -1,18 +1,8 @@
 package frc.robot.commands.complex;
 
 import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
-import frc.robot.commands.arm.ShooterElevatorPosInstant;
-import frc.robot.commands.arm.ShooterFlywheelSpeedInstant;
 import frc.robot.commands.arm.ShooterFlywheelSpeedInstantForce;
-import frc.robot.commands.arm.ShooterPivotPosInstant;
-import frc.robot.commands.arm.ShooterTrackSpeedInstant;
 import frc.robot.commands.arm.ShooterTrackSpeedInstantForce;
-import frc.robot.commands.climb.ClimbPosTolerance;
-import frc.robot.commands.intake.IntakeRollerSpeedInstant;
-import frc.robot.commands.intake.IntakeTrackSpeedInstant;
-import frc.robot.constants.ArmPositions;
-import frc.robot.constants.ClimbPositions;
-import frc.robot.constants.IntakeSpeeds;
 import frc.robot.constants.ShooterSpeeds;
 
 public class Panic extends ParallelCommandGroup {

--- a/src/main/java/frc/robot/commands/complex/PrepAmp.java
+++ b/src/main/java/frc/robot/commands/complex/PrepAmp.java
@@ -1,7 +1,6 @@
 package frc.robot.commands.complex;
 
 import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
-import frc.robot.commands.arm.ShooterElevatorPosInstant;
 import frc.robot.commands.arm.ShooterElevatorPosTolerance;
 import frc.robot.commands.arm.ShooterFlywheelSpeedInstant;
 import frc.robot.commands.arm.ShooterPivotPosInstant;

--- a/src/main/java/frc/robot/commands/complex/SpeakerAuto.java
+++ b/src/main/java/frc/robot/commands/complex/SpeakerAuto.java
@@ -2,9 +2,7 @@ package frc.robot.commands.complex;
 
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.robot.commands.arm.ShooterElevatorPosTolerance;
-import frc.robot.commands.arm.ShooterFlywheelSpeedInstant;
 import frc.robot.commands.arm.ShooterFlywheelSpeedTolerance;
-import frc.robot.commands.arm.ShooterPivotPosInstant;
 import frc.robot.commands.arm.ShooterPivotPosTolerance;
 import frc.robot.constants.ArmPositions;
 import frc.robot.constants.ShooterSpeeds;

--- a/src/main/java/frc/robot/commands/complex/TheBigYeet.java
+++ b/src/main/java/frc/robot/commands/complex/TheBigYeet.java
@@ -4,7 +4,6 @@ import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import edu.wpi.first.wpilibj2.command.WaitCommand;
 import frc.robot.commands.arm.ShooterElevatorPosInstant;
-import frc.robot.commands.arm.ShooterElevatorPosTolerance;
 import frc.robot.commands.arm.ShooterPivotPosInstant;
 import frc.robot.commands.arm.ShooterTrackSpeedInstant;
 import frc.robot.constants.ArmPositions;

--- a/src/main/java/frc/robot/commands/swervedrive/auto/TestingPaths.java
+++ b/src/main/java/frc/robot/commands/swervedrive/auto/TestingPaths.java
@@ -5,8 +5,6 @@ import com.pathplanner.lib.path.PathConstraints;
 
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
-import edu.wpi.first.math.geometry.Rotation3d;
-import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;

--- a/src/main/java/frc/robot/commands/swervedrive/drivebase/TeleopDrive.java
+++ b/src/main/java/frc/robot/commands/swervedrive/drivebase/TeleopDrive.java
@@ -4,19 +4,11 @@
 
 package frc.robot.commands.swervedrive.drivebase;
 
-import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
-import edu.wpi.first.math.kinematics.ChassisSpeeds;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
-import frc.robot.constants.ShooterSpeeds;
-import frc.robot.subsystems.ReverseKinematics;
 import frc.robot.subsystems.swervedrive.SwerveSubsystem;
-import frc.robot.util.MathUtil;
-
 import java.util.function.BooleanSupplier;
 import java.util.function.DoubleSupplier;
-import swervelib.SwerveController;
 
 /**
  * An example command that uses an example subsystem.

--- a/src/main/java/frc/robot/subsystems/IntakeRoller.java
+++ b/src/main/java/frc/robot/subsystems/IntakeRoller.java
@@ -1,11 +1,9 @@
 package frc.robot.subsystems;
 
-import com.revrobotics.CANSparkBase.ControlType;
 import com.revrobotics.CANSparkBase.IdleMode;
 import com.revrobotics.CANSparkLowLevel.MotorType;
 import com.revrobotics.CANSparkMax;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
-import frc.robot.util.PIDConfig;
 import frc.robot.util.SparkMax.SparkMaxConfig;
 import frc.robot.util.SparkMax.SparkMaxEncoderType;
 import frc.robot.util.SparkMax.SparkMaxSetup;

--- a/src/main/java/frc/robot/subsystems/IntakeTrack.java
+++ b/src/main/java/frc/robot/subsystems/IntakeTrack.java
@@ -1,13 +1,11 @@
 package frc.robot.subsystems;
 
 import com.revrobotics.CANSparkFlex;
-import com.revrobotics.CANSparkBase.ControlType;
 import com.revrobotics.CANSparkBase.IdleMode;
 import com.revrobotics.CANSparkLowLevel.MotorType;
 import com.revrobotics.CANSparkLowLevel.PeriodicFrame;
 
 import edu.wpi.first.wpilibj.DigitalInput;
-import edu.wpi.first.wpilibj.simulation.DIOSim;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.constants.ShooterSpeeds;
 

--- a/src/main/java/frc/robot/subsystems/ShooterElevator.java
+++ b/src/main/java/frc/robot/subsystems/ShooterElevator.java
@@ -11,7 +11,6 @@ import frc.robot.util.SparkMax.SparkMaxConfig;
 import frc.robot.util.SparkMax.SparkMaxEncoderType;
 import frc.robot.util.SparkMax.SparkMaxSetup;
 import frc.robot.util.SparkMax.SparkMaxStatusFrames;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 public class ShooterElevator extends SubsystemBase {

--- a/src/main/java/frc/robot/subsystems/ShooterFlywheel.java
+++ b/src/main/java/frc/robot/subsystems/ShooterFlywheel.java
@@ -1,7 +1,6 @@
 package frc.robot.subsystems;
 
 import com.revrobotics.CANSparkFlex;
-import com.revrobotics.SparkMaxPIDController;
 import com.revrobotics.SparkPIDController;
 import com.revrobotics.CANSparkBase.ControlType;
 import com.revrobotics.CANSparkBase.IdleMode;

--- a/src/main/java/frc/robot/subsystems/ShooterTrack.java
+++ b/src/main/java/frc/robot/subsystems/ShooterTrack.java
@@ -1,13 +1,11 @@
 package frc.robot.subsystems;
 
 import com.revrobotics.CANSparkFlex;
-import com.revrobotics.CANSparkBase.ControlType;
 import com.revrobotics.CANSparkBase.IdleMode;
 import com.revrobotics.CANSparkLowLevel.MotorType;
 import com.revrobotics.CANSparkLowLevel.PeriodicFrame;
 
 import edu.wpi.first.wpilibj.DigitalInput;
-import edu.wpi.first.wpilibj.simulation.DIOSim;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.constants.ShooterSpeeds;
 

--- a/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
@@ -18,8 +18,6 @@ import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.math.trajectory.Trajectory;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Filesystem;
-import edu.wpi.first.wpilibj.Timer;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;

--- a/src/main/java/frc/robot/subsystems/vision/Vision.java
+++ b/src/main/java/frc/robot/subsystems/vision/Vision.java
@@ -1,7 +1,5 @@
 package frc.robot.subsystems.vision;
 
-// import static ROBOT_TO_BLINKY
-
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.photonvision.EstimatedRobotPose;
@@ -66,17 +64,12 @@ public class Vision implements Runnable {
       if (photonPoseEstimator != null && photonCamera != null) {
         var photonResults = photonCamera.getLatestResult(); //Gets the latest camera results
 
-        // var test = VisionConstants.class.getDeclaredField("ROBOT_TO_" + photonCamera.getName().toUpperCase());
-        // test.setAccessible(true);
-        // Transform3d test2 = (Transform3d) test.get(VisionConstants.class.getClass());
-        //SmartDashboard.putString("Test", test2.toString());
         SwerveSubsystem.getInstance().getSwerveDrive().field.getObject("vision/" + photonCamera.getName()).setPose(
             photonResults.getBestTarget().getBestCameraToTarget().getX(),
             photonResults.getBestTarget().getBestCameraToTarget().getY(),
             photonResults.getBestTarget().getBestCameraToTarget().getRotation().toRotation2d());
 
-        if (photonResults
-            .hasTargets()) {
+        if (photonResults.hasTargets()) {
           //Updates the pose estimator
           photonPoseEstimator.update(photonResults).ifPresent(estimatedRobotPose -> {
             var estimatedPose = estimatedRobotPose.estimatedPose;

--- a/src/main/java/frc/robot/subsystems/vision/Vision.java
+++ b/src/main/java/frc/robot/subsystems/vision/Vision.java
@@ -23,13 +23,15 @@ public class Vision implements Runnable {
   private final PhotonPoseEstimator photonPoseEstimator;
   private final PhotonCamera photonCamera;
   private final AtomicReference<EstimatedRobotPose> atomicEstimatedRobotPose = new AtomicReference<EstimatedRobotPose>();
+  public final String cameraName;
 
   // Telemetry
   private final CountPerPeriodTelemetry runCountTelemetry;
   private final CountPerPeriodTelemetry setAtomicCountTelemetry;
 
-  public Vision(PhotonCamera cameraName, Transform3d robotToCamera) {
-    this.photonCamera = cameraName;
+  public Vision(PhotonCamera photonCamera, Transform3d robotToCamera) {
+    this.photonCamera = photonCamera;
+    cameraName = photonCamera.getName();
     PhotonPoseEstimator photonPoseEstimator = null;
 
     try {
@@ -48,10 +50,8 @@ public class Vision implements Runnable {
     this.photonPoseEstimator = photonPoseEstimator;
 
     // Initialize telemetry
-    runCountTelemetry = new CountPerPeriodTelemetry("Vision/" + cameraName.getName() + " - runs per s", 1);
-    setAtomicCountTelemetry = new CountPerPeriodTelemetry(
-        "Vision/" + cameraName.getName() + " - meas per s push",
-        1);
+    runCountTelemetry = new CountPerPeriodTelemetry("Vision/" + cameraName + " - runs per s", 1);
+    setAtomicCountTelemetry = new CountPerPeriodTelemetry("Vision/" + cameraName + " - meas per s push", 1);
   }
 
   @Override
@@ -64,7 +64,7 @@ public class Vision implements Runnable {
       if (photonPoseEstimator != null && photonCamera != null) {
         var photonResults = photonCamera.getLatestResult(); //Gets the latest camera results
 
-        SwerveSubsystem.getInstance().getSwerveDrive().field.getObject("vision/" + photonCamera.getName()).setPose(
+        SwerveSubsystem.getInstance().getSwerveDrive().field.getObject("vision/" + cameraName).setPose(
             photonResults.getBestTarget().getBestCameraToTarget().getX(),
             photonResults.getBestTarget().getBestCameraToTarget().getY(),
             photonResults.getBestTarget().getBestCameraToTarget().getRotation().toRotation2d());

--- a/src/main/java/frc/robot/subsystems/vision/Vision.java
+++ b/src/main/java/frc/robot/subsystems/vision/Vision.java
@@ -11,12 +11,9 @@ import org.photonvision.PhotonPoseEstimator.PoseStrategy;
 
 import edu.wpi.first.apriltag.AprilTagFieldLayout.OriginPosition;
 import edu.wpi.first.apriltag.AprilTagFields;
-import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.wpilibj.DriverStation;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.Constants.FieldConstants;
-import frc.robot.Constants.VisionConstants;
 import frc.robot.subsystems.swervedrive.SwerveSubsystem;
 import frc.robot.util.telemetry.CountPerPeriodTelemetry;
 

--- a/src/main/java/frc/robot/subsystems/vision/Vision.java
+++ b/src/main/java/frc/robot/subsystems/vision/Vision.java
@@ -50,9 +50,9 @@ public class Vision implements Runnable {
     this.photonPoseEstimator = photonPoseEstimator;
 
     // Initialize telemetry
-    runCountTelemetry = new CountPerPeriodTelemetry("Vision - " + cameraName.getName() + " - runs per s", 1);
+    runCountTelemetry = new CountPerPeriodTelemetry("Vision/" + cameraName.getName() + " - runs per s", 1);
     setAtomicCountTelemetry = new CountPerPeriodTelemetry(
-        "Vision - " + cameraName.getName() + " - set atomic count per s",
+        "Vision/" + cameraName.getName() + " - meas per s push",
         1);
   }
 

--- a/src/main/java/frc/robot/subsystems/vision/Vision.java
+++ b/src/main/java/frc/robot/subsystems/vision/Vision.java
@@ -14,6 +14,7 @@ import edu.wpi.first.wpilibj.DriverStation;
 import frc.robot.Constants.FieldConstants;
 import frc.robot.subsystems.swervedrive.SwerveSubsystem;
 import frc.robot.util.telemetry.CountPerPeriodTelemetry;
+import frc.robot.util.telemetry.TelemUtils;
 
 /**
  * Runnable that gets AprilTag data from PhotonVision.
@@ -50,8 +51,8 @@ public class Vision implements Runnable {
     this.photonPoseEstimator = photonPoseEstimator;
 
     // Initialize telemetry
-    runCountTelemetry = new CountPerPeriodTelemetry("Vision/" + cameraName + " - runs per s", 1);
-    setAtomicCountTelemetry = new CountPerPeriodTelemetry("Vision/" + cameraName + " - meas per s push", 1);
+    runCountTelemetry = new CountPerPeriodTelemetry(TelemUtils.getCamSDKey(cameraName, "runs per s"), 1);
+    setAtomicCountTelemetry = new CountPerPeriodTelemetry(TelemUtils.getCamSDKey(cameraName, "meas per s push"), 1);
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/vision/VisionEstimation.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionEstimation.java
@@ -185,7 +185,6 @@ public class VisionEstimation extends SubsystemBase {
                 var cameraPose = estimator.grabLatestEstimatedPose();
 
                 if (cameraPose != null) {
-                        SmartDashboard.putString("camerapose", cameraPose.estimatedPose.toString());
                         // New pose from vision
                         var pose2d = cameraPose.estimatedPose.toPose2d();
                         if (originPosition == kRedAllianceWallRightSide) {
@@ -198,5 +197,8 @@ public class VisionEstimation extends SubsystemBase {
                         // Update "get atomic count" telemetry
                         getAtomicCountTelemetry.incCount(1);
                 }
+
+                final String smartDashboardCamPoseKey = "Vision/" + estimator.cameraName + " - last pose";
+                SmartDashboard.putString(smartDashboardCamPoseKey, cameraPose != null ? cameraPose.estimatedPose.toString() : "no pose");
         }
 }

--- a/src/main/java/frc/robot/subsystems/vision/VisionEstimation.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionEstimation.java
@@ -83,17 +83,11 @@ public class VisionEstimation extends SubsystemBase {
                 allNotifier.startPeriodic(0.02);
 
                 // Initialize telemetry
-                runCountTelemetry = new CountPerPeriodTelemetry("VisionEstimation - runs per s", 1);
-                getAtomicCountInkyTelemetry = new CountPerPeriodTelemetry(
-                                "VisionEstimation - Inky - get atomic count/s", 1);
-                // getAtomicCountBlinkyTelemetry = new CountPerPeriodTelemetry("VisionEstimation
-                // - Blinky - get atomic count/s", 1);
-                getAtomicCountPinkyTelemetry = new CountPerPeriodTelemetry(
-                                "VisionEstimation - Pinky - get atomic count per s",
-                                1);
-                // getAtomicCountClydeTelemetry = new CountPerPeriodTelemetry("VisionEstimation
-                // - Clyde - get atomic count per s",
-                // 1);
+                runCountTelemetry = new CountPerPeriodTelemetry("Vision/Estimation - runs per s", 1);
+                getAtomicCountInkyTelemetry = new CountPerPeriodTelemetry("Vision/Inky - meas per s pull", 1);
+                // getAtomicCountBlinkyTelemetry = new CountPerPeriodTelemetry("Vision/Blinky - meas per s pull", 1);
+                getAtomicCountPinkyTelemetry = new CountPerPeriodTelemetry("Vision/Pinky - meas per s pull", 1);
+                // getAtomicCountClydeTelemetry = new CountPerPeriodTelemetry("Vision/Clyde - meas per s pull", 1);
         }
 
         @Override

--- a/src/main/java/frc/robot/subsystems/vision/VisionEstimation.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionEstimation.java
@@ -42,6 +42,7 @@ import frc.robot.Constants.VisionConstants;
 import frc.robot.subsystems.swervedrive.SwerveSubsystem;
 import frc.robot.util.telemetry.CountPerPeriodTelemetry;
 import frc.robot.util.telemetry.MeanPerPeriodTelemetry;
+import frc.robot.util.telemetry.TelemUtils;
 
 public class VisionEstimation extends SubsystemBase {
         private final SwerveSubsystem swerveSubsystem;
@@ -50,16 +51,10 @@ public class VisionEstimation extends SubsystemBase {
                         0.9,
                         0.9);
 
-        private final Vision backRightEstimator = new Vision(new PhotonCamera("Inky"),
-                        VisionConstants.ROBOT_TO_INKY);
-        // private final Vision frontLeftEstimator = new Vision(new
-        // PhotonCamera("Blinky"),
-        // VisionConstants.ROBOT_TO_BLINKY);
-        private final Vision backLeftEstimator = new Vision(new PhotonCamera("Pinky"),
-                        VisionConstants.ROBOT_TO_PINKY);
-        // private final Vision backLeftEstimator = new Vision(new
-        // PhotonCamera("Clyde"),
-        // VisionConstants.ROBOT_TO_CLYDE);
+        private final Vision backRightEstimator = new Vision(new PhotonCamera("Inky"), VisionConstants.ROBOT_TO_INKY);
+        // private final Vision frontLeftEstimator = new Vision(new PhotonCamera("Blinky"), VisionConstants.ROBOT_TO_BLINKY);
+        private final Vision backLeftEstimator = new Vision(new PhotonCamera("Pinky"), VisionConstants.ROBOT_TO_PINKY);
+        // private final Vision backLeftEstimator = new Vision(new PhotonCamera("Clyde"), VisionConstants.ROBOT_TO_CLYDE);
 
         private final Notifier allNotifier = new Notifier(() -> {
                 backRightEstimator.run();
@@ -90,18 +85,18 @@ public class VisionEstimation extends SubsystemBase {
                 allNotifier.startPeriodic(0.02);
 
                 // Initialize telemetry
-                runCountTelemetry = new CountPerPeriodTelemetry("Vision/Estimation - runs per s", 1);
+                runCountTelemetry = new CountPerPeriodTelemetry(TelemUtils.getCamSDKey("Estimation", "runs per s"), 1);
 
-                getAtomicCountInkyTelemetry = new CountPerPeriodTelemetry("Vision/Inky - meas per s pull", 1);
-                // getAtomicCountBlinkyTelemetry = new CountPerPeriodTelemetry("Vision/Blinky - meas per s pull", 1);
-                getAtomicCountPinkyTelemetry = new CountPerPeriodTelemetry("Vision/Pinky - meas per s pull", 1);
-                // getAtomicCountClydeTelemetry = new CountPerPeriodTelemetry("Vision/Clyde - meas per s pull", 1);
+                getAtomicCountInkyTelemetry = new CountPerPeriodTelemetry(TelemUtils.getCamSDKey("Inky", "meas per s pull"), 1);
+                // getAtomicCountBlinkyTelemetry = new CountPerPeriodTelemetry(TelemUtils.getCamSDKey("Blinky", "meas per s pull"), 1);
+                getAtomicCountPinkyTelemetry = new CountPerPeriodTelemetry(TelemUtils.getCamSDKey("Pinky", "meas per s pull"), 1);
+                // getAtomicCountClydeTelemetry = new CountPerPeriodTelemetry(TelemUtils.getCamSDKey("Clyde", "meas per s pull"), 1);
 
 
-                confidenceInkyTelemetry = new MeanPerPeriodTelemetry("Vision/Inky - confidence mult", 0.5, -999.99);
-                // confidenceBlinkyTelemetry = new MeanPerPeriodTelemetry("Vision/Blinky - confidence mult", 0.5, -999.99);
-                confidencePinkyTelemetry = new MeanPerPeriodTelemetry("Vision/Pinky - confidence mult", 0.5, -999.99);
-                // confidenceClydeTelemetry = new MeanPerPeriodTelemetry("Vision/Clyde - confidence mult", 0.5, -999.99);
+                confidenceInkyTelemetry = new MeanPerPeriodTelemetry(TelemUtils.getCamSDKey("Inky", "confidence mult"), 0.5, -999.99);
+                // confidenceBlinkyTelemetry = new MeanPerPeriodTelemetry(TelemUtils.getCamSDKey("Blinky", "confidence mult"), 0.5, -999.99);
+                confidencePinkyTelemetry = new MeanPerPeriodTelemetry(TelemUtils.getCamSDKey("Pinky", "confidence mult"), 0.5, -999.99);
+                // confidenceClydeTelemetry = new MeanPerPeriodTelemetry(TelemUtils.getCamSDKey("Clyde", "confidence mult"), 0.5, -999.99);
         }
 
         @Override
@@ -198,7 +193,7 @@ public class VisionEstimation extends SubsystemBase {
                         getAtomicCountTelemetry.incCount(1);
                 }
 
-                final String smartDashboardCamPoseKey = "Vision/" + estimator.cameraName + " - last pose";
+                final String smartDashboardCamPoseKey = TelemUtils.getCamSDKey(estimator.cameraName, "last pose");
                 SmartDashboard.putString(smartDashboardCamPoseKey, cameraPose != null ? cameraPose.estimatedPose.toString() : "no pose");
         }
 }

--- a/src/main/java/frc/robot/util/telemetry/TelemUtils.java
+++ b/src/main/java/frc/robot/util/telemetry/TelemUtils.java
@@ -1,0 +1,17 @@
+package frc.robot.util.telemetry;
+
+/**
+ * Utils for telemetry.
+ */
+public class TelemUtils {
+    /** Generates a key name to use when sending camera-specific telemetry to SmartDashboard.
+     * 
+     * @param cameraName the name of the camera, e.g. "Inky", "Pinky", etc.
+     * @param metricDesc very short and abbreviated description of the metric. Needs to be short so
+     *  that it fits on SmartDashboard. e.g. "runs per s", "meas per s push", "meas per s pull", etc.
+     * @return a concatenated string with the "Vision/" prefix. E.g."Vision/Inky - runs per s".
+     */
+    public static String getCamSDKey(String cameraName, String metricDesc) {
+        return "Vision/" + cameraName + " - " + metricDesc;
+    }
+}

--- a/src/main/java/swervelib/encoders/SparkMaxEncoderSwerve.java
+++ b/src/main/java/swervelib/encoders/SparkMaxEncoderSwerve.java
@@ -7,7 +7,6 @@ import com.revrobotics.SparkAbsoluteEncoder.Type;
 import java.util.function.Supplier;
 import swervelib.motors.SwerveMotor;
 import swervelib.telemetry.Alert;
-import swervelib.telemetry.Alert.AlertType;
 
 /**
  * SparkMax absolute encoder, attached through the data port.

--- a/src/main/java/swervelib/motors/SparkFlexSwerve.java
+++ b/src/main/java/swervelib/motors/SparkFlexSwerve.java
@@ -363,7 +363,6 @@ public class SparkFlexSwerve extends SwerveMotor
   @Override
   public void setReference(double setpoint, double feedforward)
   {
-    boolean possibleBurnOutIssue = true;
 //    int pidSlot =
 //        isDriveMotor ? SparkMAX_slotIdx.Velocity.ordinal() : SparkMAX_slotIdx.Position.ordinal();
     int pidSlot = 0;

--- a/src/main/java/swervelib/motors/SparkMaxSwerve.java
+++ b/src/main/java/swervelib/motors/SparkMaxSwerve.java
@@ -247,7 +247,6 @@ public class SparkMaxSwerve extends SwerveMotor
   {
 //    int pidSlot =
 //        isDriveMotor ? SparkMAX_slotIdx.Velocity.ordinal() : SparkMAX_slotIdx.Position.ordinal();
-    int pidSlot = 0;
     configureSparkMax(() -> pid.setP(config.p));
     configureSparkMax(() -> pid.setI(config.i));
     configureSparkMax(() -> pid.setD(config.d));
@@ -351,7 +350,6 @@ public class SparkMaxSwerve extends SwerveMotor
   @Override
   public void setReference(double setpoint, double feedforward)
   {
-    boolean possibleBurnOutIssue = true;
 //    int pidSlot =
 //        isDriveMotor ? SparkMAX_slotIdx.Velocity.ordinal() : SparkMAX_slotIdx.Position.ordinal();
     int pidSlot = 0;


### PR DESCRIPTION
- show confidence multiplier and estimated pose per camera on SmartDashboard
- shortened and organized the vision-related telemetry in the format `Vision/<camera name> - <description of data>`
- removed unused imports